### PR TITLE
feat(auth): JWT auth service + routes — P1-BACK-02 & P1-BACK-03

### DIFF
--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -1,10 +1,17 @@
 """FastAPI dependencies — database session, current user."""
 
+import uuid
 from typing import Generator
 
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
+from app.core.security import decode_token
 from app.database import SessionLocal
+from app.models.user import User
+
+bearer_scheme = HTTPBearer()
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -16,8 +23,25 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
-# TODO: Implement get_current_user dependency
-# - Extract JWT from Authorization header
-# - Decode and validate token
-# - Return User object with tenant_id
-# def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)) -> User:
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    """Extract and validate JWT, return the authenticated User."""
+    try:
+        payload = decode_token(credentials.credentials)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
+
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+
+    user = db.query(User).filter(User.id == uuid.UUID(user_id)).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return user

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,10 +1,37 @@
 """JWT token creation and verification, password hashing."""
 
+from datetime import datetime, timedelta, timezone
 
-# TODO: Implement in US-002
-# - create_access_token(data: dict) -> str
-# - create_refresh_token(data: dict) -> str
-# - decode_token(token: str) -> dict
-# - hash_password(password: str) -> str
-# - verify_password(plain: str, hashed: str) -> bool
-# Uses: python-jose, passlib[bcrypt]
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from app.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(data: dict) -> str:
+    payload = data.copy()
+    payload["exp"] = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
+    payload["type"] = "access"
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+
+
+def create_refresh_token(data: dict) -> str:
+    payload = data.copy()
+    payload["exp"] = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
+    payload["type"] = "refresh"
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.algorithm)
+
+
+def decode_token(token: str) -> dict:
+    """Decode and validate a JWT. Raises JWTError on failure."""
+    return jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.routers import auth
 
 app = FastAPI(
     title="DataPilot API",
@@ -17,14 +18,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
-# TODO: Include routers in Phase 1 implementation
-# from app.routers import auth, workspaces, data_sources, dashboards, ai
-# app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
-# app.include_router(workspaces.router, prefix="/api/v1/workspaces", tags=["workspaces"])
-# app.include_router(data_sources.router, prefix="/api/v1/data-sources", tags=["data-sources"])
-# app.include_router(dashboards.router, prefix="/api/v1/dashboards", tags=["dashboards"])
-# app.include_router(ai.router, prefix="/api/v1/ai", tags=["ai"])
+app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 
 
 @app.get("/health")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,9 +1,43 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.dependencies import get_current_user, get_db
+from app.models.user import User
+from app.schemas.auth import (
+    AccessTokenResponse,
+    RefreshRequest,
+    TokenResponse,
+    UserLogin,
+    UserRegister,
+    UserResponse,
+)
+from app.services.auth_service import (
+    authenticate_user,
+    create_tokens,
+    refresh_access_token,
+    register_user,
+)
 
 router = APIRouter()
 
 
-# TODO: Implement in US-002
-# POST /login
-# POST /register
-# POST /refresh
+@router.post("/register", response_model=UserResponse, status_code=201)
+def register(data: UserRegister, db: Session = Depends(get_db)):
+    user = register_user(db, data)
+    return user
+
+
+@router.post("/login", response_model=TokenResponse)
+def login(data: UserLogin, db: Session = Depends(get_db)):
+    user = authenticate_user(db, data.email, data.password)
+    return create_tokens(user)
+
+
+@router.post("/refresh", response_model=AccessTokenResponse)
+def refresh(data: RefreshRequest):
+    return refresh_access_token(data.refresh_token)
+
+
+@router.get("/me", response_model=UserResponse)
+def me(current_user: User = Depends(get_current_user)):
+    return current_user

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,40 @@
+"""Pydantic schemas for auth endpoints."""
+
+import uuid
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserRegister(BaseModel):
+    email: EmailStr
+    password: str
+    tenant_id: uuid.UUID
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class AccessTokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    tenant_id: uuid.UUID
+    role: str
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,8 +1,68 @@
-"""Authentication service — handles user registration, login, token refresh."""
+"""Authentication service — user registration, login, token refresh."""
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+from app.models.user import User
+from app.schemas.auth import AccessTokenResponse, TokenResponse, UserRegister
 
 
-# TODO: Implement in US-002
-# - register_user(email, password) -> User
-# - authenticate_user(email, password) -> User | None
-# - create_tokens(user) -> { access_token, refresh_token }
-# - refresh_access_token(refresh_token) -> { access_token }
+def register_user(db: Session, data: UserRegister) -> User:
+    """Create a new user. Raises 409 if email already exists."""
+    existing = db.query(User).filter(User.email == data.email).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
+
+    user = User(
+        id=uuid.uuid4(),
+        email=data.email,
+        hashed_password=hash_password(data.password),
+        tenant_id=data.tenant_id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def authenticate_user(db: Session, email: str, password: str) -> User:
+    """Validate credentials. Raises 401 on failure."""
+    user = db.query(User).filter(User.email == email).first()
+    if not user or not verify_password(password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+    return user
+
+
+def create_tokens(user: User) -> TokenResponse:
+    """Generate access and refresh tokens for a user."""
+    payload = {"sub": str(user.id), "tenant_id": str(user.tenant_id), "role": user.role}
+    return TokenResponse(
+        access_token=create_access_token(payload),
+        refresh_token=create_refresh_token(payload),
+    )
+
+
+def refresh_access_token(refresh_token: str) -> AccessTokenResponse:
+    """Validate refresh token and issue a new access token."""
+    try:
+        payload = decode_token(refresh_token)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+
+    if payload.get("type") != "refresh":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+
+    new_payload = {"sub": payload["sub"], "tenant_id": payload["tenant_id"], "role": payload["role"]}
+    return AccessTokenResponse(access_token=create_access_token(new_payload))


### PR DESCRIPTION
## Summary
- Implémentation complète du service d'authentification JWT
- Routes `/register`, `/login`, `/refresh`, `/me`
- `get_current_user` dependency pour protéger les futurs endpoints

## Changes

### `app/core/security.py`
- `hash_password` / `verify_password` (passlib bcrypt)
- `create_access_token` (30min) / `create_refresh_token` (7j)
- `decode_token` (python-jose)

### `app/services/auth_service.py`
- `register_user` — crée User, 409 si email dupliqué
- `authenticate_user` — vérifie credentials, 401 si invalide
- `create_tokens` — génère access + refresh token avec tenant_id dans payload
- `refresh_access_token` — valide refresh token, retourne nouveau access token

### `app/schemas/auth.py`
- `UserRegister`, `UserLogin`, `TokenResponse`, `AccessTokenResponse`, `RefreshRequest`, `UserResponse`
- `hashed_password` jamais exposé

### `app/core/dependencies.py`
- `get_current_user` — extrait Bearer JWT, valide, retourne User

### `app/routers/auth.py`
- `POST /api/v1/auth/register` → 201 + UserResponse
- `POST /api/v1/auth/login` → TokenResponse
- `POST /api/v1/auth/refresh` → AccessTokenResponse
- `GET /api/v1/auth/me` → UserResponse (protégé)

### `app/main.py`
- Router auth enregistré

## Test plan
- [ ] `POST /register` avec email unique → 201
- [ ] `POST /register` avec email dupliqué → 409
- [ ] `POST /login` avec bons credentials → tokens
- [ ] `POST /login` avec mauvais password → 401
- [ ] `POST /refresh` avec refresh token valide → nouveau access token
- [ ] `GET /me` avec token valide → user info
- [ ] `GET /me` sans token → 403

Closes #3
Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)