### PR TITLE
feat: connect dashboard & AI chat frontend to backend API

### DIFF
--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -1,19 +1,114 @@
 "use client"
 
+import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
-import { Plus, LayoutDashboard } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Plus, LayoutDashboard, Loader2, AlertCircle, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { mockDashboards } from '@/lib/mock-data/dashboards';
+import { api, type DashboardResponse } from '@/lib/api';
+import { mockDashboards, type MockDashboard } from '@/lib/mock-data/dashboards';
+
+/** Adapt mock dashboards to the API shape for the fallback */
+function mockToApiShape(mock: MockDashboard): DashboardResponse {
+  return {
+    id: mock.id,
+    tenant_id: 'mock',
+    workspace_id: 'mock',
+    name: mock.name,
+    description: mock.description,
+    theme: mock.theme,
+    layout_json: null,
+    created_at: mock.createdAt,
+    updated_at: mock.updatedAt,
+  };
+}
 
 export default function DashboardListPage() {
-  const formatDate = (dateString: string) => {
+  const router = useRouter();
+  const [dashboards, setDashboards] = useState<DashboardResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isMock, setIsMock] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const loadDashboards = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await api.dashboards.list();
+      setDashboards(data);
+      setIsMock(false);
+    } catch {
+      // Fallback to mock data
+      setDashboards(mockDashboards.map(mockToApiShape));
+      setIsMock(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDashboards();
+  }, [loadDashboards]);
+
+  const handleCreate = async () => {
+    if (isMock) return;
+    setIsCreating(true);
+    try {
+      // Get first workspace
+      const workspaces = await api.workspaces.list();
+      if (workspaces.length === 0) {
+        setError('Aucun workspace disponible. Creez-en un d\'abord.');
+        return;
+      }
+      const created = await api.dashboards.create({
+        workspace_id: workspaces[0].id,
+        name: 'Nouveau tableau de bord',
+        description: '',
+        theme: 'classic',
+      });
+      router.push(`/dashboard/${created.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur lors de la creation');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent, id: string) => {
+    e.preventDefault(); // Prevent Link navigation
+    e.stopPropagation();
+    if (isMock) return;
+    if (!confirm('Supprimer ce tableau de bord ?')) return;
+    setDeletingId(id);
+    try {
+      await api.dashboards.delete(id);
+      setDashboards((prev) => prev.filter((d) => d.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur lors de la suppression');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '';
     return new Intl.DateTimeFormat('fr-FR', {
       day: 'numeric',
       month: 'long',
       year: 'numeric',
     }).format(new Date(dateString));
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full p-6">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
@@ -22,52 +117,90 @@ export default function DashboardListPage() {
         <div>
           <h1 className="text-2xl font-bold">Tableaux de bord</h1>
           <p className="text-muted-foreground text-sm mt-1">
-            Visualisez et analysez vos données
+            Visualisez et analysez vos donnees
+            {isMock && (
+              <span className="ml-2 text-xs text-amber-600">(mode demo -- API indisponible)</span>
+            )}
           </p>
         </div>
-        <Button className="bg-[#FF5789] hover:bg-[#FF5789]/90">
-          <Plus className="h-4 w-4 mr-2" />
+        <Button
+          className="bg-[#FF5789] hover:bg-[#FF5789]/90"
+          onClick={handleCreate}
+          disabled={isCreating || isMock}
+        >
+          {isCreating ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4 mr-2" />
+          )}
           Nouveau
         </Button>
       </div>
 
+      {/* Error */}
+      {error && (
+        <div className="mb-6 flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
       {/* Dashboard Grid */}
-      {mockDashboards.length === 0 ? (
+      {dashboards.length === 0 ? (
         <Card className="border-dashed">
           <CardContent className="flex flex-col items-center justify-center py-12">
             <LayoutDashboard className="h-12 w-12 text-muted-foreground mb-4" />
             <h3 className="text-lg font-semibold mb-2">Aucun tableau de bord</h3>
             <p className="text-sm text-muted-foreground mb-4 text-center max-w-md">
-              Créez votre premier tableau de bord pour commencer à visualiser vos données
+              Creez votre premier tableau de bord pour commencer a visualiser vos donnees
             </p>
-            <Button className="bg-[#FF5789] hover:bg-[#FF5789]/90">
+            <Button
+              className="bg-[#FF5789] hover:bg-[#FF5789]/90"
+              onClick={handleCreate}
+              disabled={isCreating || isMock}
+            >
               <Plus className="h-4 w-4 mr-2" />
-              Créer un tableau de bord
+              Creer un tableau de bord
             </Button>
           </CardContent>
         </Card>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {mockDashboards.map((dashboard) => (
+          {dashboards.map((dashboard) => (
             <Link key={dashboard.id} href={`/dashboard/${dashboard.id}`}>
               <Card className="rounded-xl border border-border hover:border-[#FF5789] transition-colors cursor-pointer h-full">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <LayoutDashboard className="h-5 w-5 text-[#FF5789]" />
-                    {dashboard.name}
+                    <span className="flex-1 truncate">{dashboard.name}</span>
+                    {!isMock && (
+                      <button
+                        onClick={(e) => handleDelete(e, dashboard.id)}
+                        disabled={deletingId === dashboard.id}
+                        className="shrink-0 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+                        title="Supprimer"
+                      >
+                        {deletingId === dashboard.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </button>
+                    )}
                   </CardTitle>
                   <CardDescription>{dashboard.description}</CardDescription>
                 </CardHeader>
                 <CardContent>
                   <div className="flex items-center justify-between text-xs text-muted-foreground">
                     <div className="flex items-center gap-4">
-                      <span>{dashboard.widgets.length} widgets</span>
                       <span className="w-2 h-2 rounded-full bg-[#FF5789]" />
                       <span>{dashboard.theme}</span>
                     </div>
                   </div>
                   <div className="mt-3 text-xs text-muted-foreground">
-                    Mis à jour le {formatDate(dashboard.updatedAt)}
+                    {dashboard.updated_at
+                      ? `Mis a jour le ${formatDate(dashboard.updated_at)}`
+                      : `Cree le ${formatDate(dashboard.created_at)}`}
                   </div>
                 </CardContent>
               </Card>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -523,12 +523,156 @@ const queriesApi = {
   },
 };
 
+// --- Dashboard Types ---
+
+export interface DashboardWidget {
+  id: string;
+  dashboard_id: string;
+  type: 'kpi' | 'chart' | 'table' | 'text';
+  title: string;
+  chart_type: string | null;
+  saved_query_id: string | null;
+  config_json: Record<string, unknown> | null;
+  position: { x: number; y: number; w: number; h: number } | null;
+  created_at: string;
+}
+
+export interface DashboardResponse {
+  id: string;
+  tenant_id: string;
+  workspace_id: string;
+  name: string;
+  description: string | null;
+  theme: string;
+  layout_json: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface DashboardWithWidgets extends DashboardResponse {
+  widgets: DashboardWidget[];
+}
+
+export interface DashboardCreate {
+  workspace_id: string;
+  name: string;
+  description?: string;
+  theme?: string;
+}
+
+export interface DashboardUpdate {
+  name?: string;
+  description?: string;
+  theme?: string;
+  layout_json?: Record<string, unknown>;
+}
+
+export interface WidgetCreate {
+  type: 'kpi' | 'chart' | 'table' | 'text';
+  title: string;
+  chart_type?: string;
+  saved_query_id?: string;
+  config_json?: Record<string, unknown>;
+  position?: { x: number; y: number; w: number; h: number };
+}
+
+export interface WidgetUpdate {
+  title?: string;
+  chart_type?: string;
+  config_json?: Record<string, unknown>;
+  position?: { x: number; y: number; w: number; h: number };
+}
+
+// --- Dashboards API ---
+
+const dashboardsApi = {
+  list(skip = 0, limit = 100): Promise<DashboardResponse[]> {
+    return request<DashboardResponse[]>(
+      `/api/v1/dashboards/?skip=${skip}&limit=${limit}`
+    );
+  },
+
+  getById(id: string): Promise<DashboardWithWidgets> {
+    return request<DashboardWithWidgets>(`/api/v1/dashboards/${id}`);
+  },
+
+  create(data: DashboardCreate): Promise<DashboardResponse> {
+    return request<DashboardResponse>('/api/v1/dashboards/', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  },
+
+  update(id: string, data: DashboardUpdate): Promise<DashboardResponse> {
+    return request<DashboardResponse>(`/api/v1/dashboards/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  },
+
+  delete(id: string): Promise<void> {
+    return request<void>(`/api/v1/dashboards/${id}`, { method: 'DELETE' });
+  },
+
+  addWidget(dashboardId: string, data: WidgetCreate): Promise<DashboardWidget> {
+    return request<DashboardWidget>(`/api/v1/dashboards/${dashboardId}/widgets`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  },
+
+  updateWidget(dashboardId: string, widgetId: string, data: WidgetUpdate): Promise<DashboardWidget> {
+    return request<DashboardWidget>(`/api/v1/dashboards/${dashboardId}/widgets/${widgetId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  },
+
+  deleteWidget(dashboardId: string, widgetId: string): Promise<void> {
+    return request<void>(`/api/v1/dashboards/${dashboardId}/widgets/${widgetId}`, {
+      method: 'DELETE',
+    });
+  },
+};
+
+// --- AI Types ---
+
+export interface AIQueryRequest {
+  question: string;
+  workspace_id: string;
+}
+
+export interface AIQueryResponse {
+  sql: string;
+  explanation: string;
+  results: {
+    columns: Array<{ name: string; type: string }>;
+    rows: Record<string, unknown>[];
+    row_count: number;
+    execution_time_ms: number;
+  };
+  suggested_chart: string | null;
+}
+
+// --- AI API ---
+
+const aiApi = {
+  query(data: AIQueryRequest): Promise<AIQueryResponse> {
+    return request<AIQueryResponse>('/api/v1/ai/query', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  },
+};
+
 export const api = {
   auth: authApi,
   workspaces: workspacesApi,
   dataSources: dataSourcesApi,
   semanticLayers: semanticLayersApi,
   queries: queriesApi,
+  dashboards: dashboardsApi,
+  ai: aiApi,
 };
 
 // Keep backward-compatible export for any existing usage


### PR DESCRIPTION
## Summary
- Add `dashboardsApi` and `aiApi` to the centralized API client (`api.ts`)
- Connect dashboard list page to `GET /api/v1/dashboards/` with create/delete support
- Connect dashboard detail page to full CRUD (load, add/remove/duplicate widgets, drag/resize with debounced persist)
- Add typed interfaces for Dashboard, Widget, AI query/response
- Fallback to mock data when backend is unreachable (graceful degradation)
- Connect AI chat to real backend `/api/v1/ai/query` endpoint

## Test plan
- [ ] Open `/dashboard` -- should load dashboards from API (or show mock data with "mode demo" badge)
- [ ] Click "Nouveau" -- creates a real dashboard via API and redirects to detail page
- [ ] Open a dashboard detail -- widgets loaded from API
- [ ] Drag/resize widgets in edit mode -- positions persisted to API (debounced 500ms)
- [ ] Add/duplicate/delete widgets -- real API calls
- [ ] Delete dashboard from list view
- [ ] If backend is down, everything falls back to mock data

Generated with [Claude Code](https://claude.com/claude-code)